### PR TITLE
feat!: standardize CLI parameters for POSIX/GNU compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This project has two related repositories that should be kept synchronized:
 ```bash
 # Local development and testing
 node index.js --help                 # Test CLI locally
-node index.js -b 100 -v 30 -f 7     # Test with parameters
+node index.js -b 100 -r 30 -f 7     # Test with parameters
 node index.js init-config            # Test config initialization
 
 # Package management  
@@ -80,7 +80,7 @@ gcalc -b 50 -f 8
 
 **Command Structure:**
 - Both `gift-calc` and `gcalc` commands point to same `index.js`
-- Standard CLI options: `-b/--basevalue`, `-v/--variation`, `-f/--friend-score`
+- Standard CLI options: `-b/--basevalue`, `-r/--variation`, `-f/--friend-score`
 
 ## GitHub Tool Usage
 

--- a/src/core.js
+++ b/src/core.js
@@ -121,7 +121,7 @@ export function parseArguments(args, defaultConfig = {}) {
     return config;
   }
   
-  if (args[0] === '--version') {
+  if (args[0] === '--version' || args[0] === '-v' || args[0] === '-V') {
     config.command = 'version';
     return config;
   }
@@ -139,7 +139,7 @@ export function parseArguments(args, defaultConfig = {}) {
       break;
     }
     
-    if (arg === '--version') {
+    if (arg === '--version' || arg === '-v' || arg === '-V') {
       config.command = 'version';
       break;
     }
@@ -154,7 +154,7 @@ export function parseArguments(args, defaultConfig = {}) {
       }
     }
     
-    if (arg === '-v' || arg === '--variation') {
+    if (arg === '-r' || arg === '--variation') {
       const nextArg = args[i + 1];
       if (nextArg && !isNaN(nextArg)) {
         const varValue = parseFloat(nextArg);
@@ -162,10 +162,10 @@ export function parseArguments(args, defaultConfig = {}) {
           config.variation = varValue;
           i++; // Skip the next argument as it's the value
         } else {
-          throw new Error('-v/--variation must be between 0 and 100');
+          throw new Error('-r/--variation must be between 0 and 100');
         }
       } else {
-        throw new Error('-v/--variation requires a numeric value');
+        throw new Error('-r/--variation requires a numeric value');
       }
     }
     
@@ -209,7 +209,7 @@ export function parseArguments(args, defaultConfig = {}) {
       }
     }
     
-    if (arg === '-cp' || arg === '--copy') {
+    if (arg === '-C' || arg === '--copy') {
       config.copyToClipboard = true;
     }
     
@@ -396,8 +396,10 @@ COMMANDS:
   naughty-list, nl            Manage the naughty list (add/remove/list/search)
 
 OPTIONS:
+  -h, --help                  Show this help message
+  -v, -V, --version           Show version information
   -b, --basevalue <number>    Set the base value for gift calculation (default: 70)
-  -v, --variation <percent>   Set variation percentage (0-100, default: 20)
+  -r, --variation <percent>   Set variation percentage (0-100, default: 20)
   -f, --friend-score <1-10>   Friend score affecting gift amount bias (default: 5)
                               Higher scores increase chance of higher amounts
   -n, --nice-score <0-10>     Nice score affecting gift amount bias (default: 5)
@@ -410,9 +412,7 @@ OPTIONS:
   --asshole                   Set nice score to 0 (no gift)
   --dickhead                  Set nice score to 0 (no gift)
   --no-log                    Disable logging to file (logging enabled by default)
-  -cp, --copy                 Copy amount (without currency) to clipboard
-  -h, --help                  Show this help message
-  --version                   Show version information
+  -C, --copy                  Copy amount (without currency) to clipboard
 
 NAUGHTY LIST OPTIONS:
   --remove, -r                Remove person from naughty list (use with naughty-list command)
@@ -435,11 +435,11 @@ EXAMPLES:
   gift-calc update-config               # Update existing configuration file
   gift-calc log                         # Open log file with less
   gift-calc -b 100                      # Base value of 100
-  gcalc -b 100 -v 30 -d 0               # Base 100, 30% variation, no decimals
+  gcalc -b 100 -r 30 -d 0               # Base 100, 30% variation, no decimals
   gift-calc --name "Alice" -c USD       # Gift for Alice in USD currency
   gcalc -b 50 -f 9 --name "Bob"         # Gift for Bob (with logging by default)
-  gift-calc -c EUR -d 1 -cp --no-log    # Use defaults with EUR, copy but no log
-  gcalc --name "Charlie" -b 80 -cp      # Gift for Charlie, copy to clipboard
+  gift-calc -c EUR -d 1 -C --no-log     # Use defaults with EUR, copy but no log
+  gcalc --name "Charlie" -b 80 -C       # Gift for Charlie, copy to clipboard
   gift-calc -f 8 -n 9                   # High friend and nice scores
   gift-calc -n 0 -b 100                 # No gift (nice score 0)
   gift-calc --asshole --name "Kevin"    # No gift for asshole Kevin

--- a/test/additional-coverage.test.js
+++ b/test/additional-coverage.test.js
@@ -145,7 +145,7 @@ describe('Additional Coverage Tests', () => {
     test('should recognize clipboard copy flags', async () => {
       const { parseArguments } = await import(path.join(process.cwd(), 'src', 'core.js'));
       
-      const config1 = parseArguments(['-cp']);
+      const config1 = parseArguments(['-C']);
       expect(config1.copyToClipboard).toBe(true);
       
       const config2 = parseArguments(['--copy']);
@@ -369,7 +369,7 @@ describe('Additional Coverage Tests', () => {
     });
 
     test('should validate parameter ranges', () => {
-      const result1 = runCLI('-v 150');
+      const result1 = runCLI('-r 150');
       expect(result1.success).toBe(false);
       expect(result1.stderr).toMatch(/must be between 0 and 100/);
       
@@ -387,7 +387,7 @@ describe('Additional Coverage Tests', () => {
       expect(result1.success).toBe(false);
       expect(result1.stderr).toMatch(/requires a numeric value/);
       
-      const result2 = runCLI('-v xyz');
+      const result2 = runCLI('-r xyz');
       expect(result2.success).toBe(false);
       expect(result2.stderr).toMatch(/requires a numeric value/);
     });
@@ -398,11 +398,11 @@ describe('Additional Coverage Tests', () => {
       expect(result1.success).toBe(true);
       
       // Zero values
-      const result2 = runCLI('-v 0 -b 100 --no-log');
+      const result2 = runCLI('-r 0 -b 100 --no-log');
       expect(result2.success).toBe(true);
       
       // Maximum values
-      const result3 = runCLI('-v 100 -d 10 --no-log');
+      const result3 = runCLI('-r 100 -d 10 --no-log');
       expect(result3.success).toBe(true);
     });
   });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -154,7 +154,7 @@ describe('Configuration and File Handling Tests', () => {
       
       // But CLI validation should still fail for invalid CLI args
       expect(() => parseArguments(['-f', '11'], defaultConfig)).toThrow(/friend-score must be between 1 and 10/);
-      expect(() => parseArguments(['-v', '101'], defaultConfig)).toThrow(/variation must be between 0 and 100/);
+      expect(() => parseArguments(['-r', '101'], defaultConfig)).toThrow(/variation must be between 0 and 100/);
     });
   });
 
@@ -200,7 +200,7 @@ describe('Configuration and File Handling Tests', () => {
     });
 
     test('should handle boolean and special values', () => {
-      const config = parseArguments(['--no-log', '-cp', '--max']);
+      const config = parseArguments(['--no-log', '-C', '--max']);
       expect(config.logToFile).toBe(false);
       expect(config.copyToClipboard).toBe(true);
       expect(config.useMaximum).toBe(true);

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -204,12 +204,12 @@ describe('Gift Calculator Core Tests', () => {
   describe('Error Handling', () => {
     test('should validate numeric requirements', () => {
       expect(() => parseArguments(['-b', 'abc'])).toThrow(/requires a numeric value/);
-      expect(() => parseArguments(['-v', 'xyz'])).toThrow(/requires a numeric value/);
+      expect(() => parseArguments(['-r', 'xyz'])).toThrow(/requires a numeric value/);
       expect(() => parseArguments(['-f', 'bad'])).toThrow(/requires a numeric value/);
     });
 
     test('should validate ranges', () => {
-      expect(() => parseArguments(['-v', '101'])).toThrow(/must be between 0 and 100/);
+      expect(() => parseArguments(['-r', '101'])).toThrow(/must be between 0 and 100/);
       expect(() => parseArguments(['-d', '11'])).toThrow(/must be between 0 and 10/);
       expect(() => parseArguments(['-f', '0'])).toThrow(/must be between 1 and 10/);
     });


### PR DESCRIPTION
## Summary

This PR implements a comprehensive restructuring of CLI parameters to follow universal POSIX/GNU standards and conventions. The changes fix long-standing violations of established CLI practices while maintaining all existing functionality.

### Breaking Changes

- **`-v` parameter**: Changed from `--variation` to `--version` (universal CLI standard)
- **Variation parameter**: Changed from `-v` to `-r` (thinking "range"/"randomness") 
- **Copy parameter**: Changed from `-cp` to `-C` (POSIX single-character compliance)
- **Version flags**: Added `-V` as alternative version flag following conventions

### Benefits

- ✅ **Standards Compliance**: Aligns with decades of CLI conventions users expect
- ✅ **POSIX Compliance**: Single-character short options only
- ✅ **GNU Compliance**: Proper `--help` and version option ordering
- ✅ **User Familiarity**: `-v` for version is universal across CLI tools
- ✅ **Maintainability**: Cleaner, more predictable parameter structure

### Implementation Details

**Core Changes:**
- Updated `parseArguments()` function in `src/core.js`
- Modified help text ordering (version first, per standards)
- Updated all examples and documentation

**Testing:**
- All 160 tests updated and passing
- Comprehensive parameter validation maintained
- Error messages updated with new parameter names

**Documentation:**
- Help text restructured following GNU conventions
- All examples updated throughout codebase
- CLAUDE.md synchronized with new parameters
- Website documentation updated separately

### Migration

**Before:**
```bash
gift-calc -v 30 -cp        # Old way
```

**After:** 
```bash
gift-calc -r 30 -C         # New standards-compliant way
gift-calc -v               # Now shows version (universal standard)
```

Long-form options remain unchanged for backward compatibility where possible:
- `--variation` still works (now with `-r`)  
- `--copy` still works (now with `-C`)
- `--version` enhanced with `-v` and `-V` support

### Test Results

```
✓ 160 tests passing
✓ All parameter validation working
✓ No regressions introduced
✓ Help system fully updated
```

This change brings gift-calc in line with established CLI tool conventions and will make it more intuitive for users familiar with standard command-line interfaces.